### PR TITLE
add `gpt-4o` support for `num_tokens`

### DIFF
--- a/oai_utils/openai_utils.py
+++ b/oai_utils/openai_utils.py
@@ -96,7 +96,10 @@ def num_tokens(messages: list[dict[str, str]] | str, model: str = "gpt-4") -> in
             4  # every message follows <|start|>{role/name}\n{content}<|end|>\n
         )
         tokens_per_name = -1  # if there's a name, the role is omitted
-    elif model == "gpt-4":
+    elif model in [
+        "gpt-4",
+        "gpt-4o",  # TODO: confirm gpt-4o rules are same as gpt-4, see https://github.com/related-sciences/oai_utils/pull/2
+    ]:
         tokens_per_message = 3
         tokens_per_name = 1
     else:

--- a/oai_utils/tests/openai_utils_test.py
+++ b/oai_utils/tests/openai_utils_test.py
@@ -6,8 +6,19 @@ from oai_utils import (
     chat_completion_batch,
     embedding,
 )
+from oai_utils.openai_utils import num_tokens
 
 pytestmark = pytest.mark.openai_api_tests
+
+
+@pytest.mark.parametrize("model", ["gpt-3.5-turbo", "gpt-4", "gpt-4o"])
+def test_support_different_model_tokens(model):
+    assert (
+        num_tokens(
+            "What is the answer to life, the universe, and everything?", model=model
+        )
+        == 13
+    )
 
 
 def test_chat_completion__dummy():


### PR DESCRIPTION
Without support in `num_tokens` for the `gpt-4o`model, running `OpenAIChatCompletionRequest` with `model=gpt-4o` results in a `Failure`:

```python
requests = [OpenAIChatCompletionRequest("what's the answer to life?", model="gpt-4o")]
responses = list(chat_completion_batch(requests, label="prompt"))

responses[0].response
# Failure(_value=(OpenAIChatCompletionRequest(messages=[{'role': 'user', 'content': "what's the answer to life?"}], model='gpt-4o', temperature=0.8, top_p=1.0, n=1, stop=None, max_tokens=None, presence_penalty=0.0, frequency_penalty=0.0, logit_bias=None, metadata=None), NotImplementedError('num_tokens_from_messages() is not implemented for model gpt-4o. See https://github.com/openai/openai-python/blob/main/chatml.md for information on how messages are converted to tokens.')))
```

Section 6 of the [OpenAI cookbook for counting tokens](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb) doesn't lay out token counting rules for `gpt-4o` like it does for the other models (checked main for newest version of the notebook). I tested a few messages and got the same results for both `gpt-4` and `gpt-4o` so it would appear they count tokens the same, though it would be good to confirm this.

<details><summary>Testing tokens are same between gpt-4 and gpt-4o</summary>
<p>

```python
from oai_utils.openai_utils import num_tokens


all_example_messages = [
    	[{"role":"user", "content": "hi"}],
    	[{"role":"user", "content": "a longer message"}],
    	[{"role":"user", "content": "a much longer message indeed"}],
]
for example_messages in all_example_messages:
    for model in ["gpt-4", "gpt-4o"]:
        print(model)
        print(f"{num_tokens(example_messages, model)} prompt tokens counted by num_tokens().")
        response = openai.ChatCompletion.create(
            model=model,
            messages=example_messages,
            temperature=0,
            max_tokens=1,  # we're only counting input tokens here, so let's not waste tokens on the output
        )
        print(f'{response["usage"]["prompt_tokens"]} prompt tokens counted by the OpenAI API.')
        print()
``` 

</p>
</details> 